### PR TITLE
adding node 16 runner support

### DIFF
--- a/src/promote-artifact-version-task/task.json
+++ b/src/promote-artifact-version-task/task.json
@@ -50,6 +50,10 @@
     "execution": {
         "Node10": {
             "target": "index.js"
+        },
+        "Node16": {
+          "target": "bash.js",
+          "argumentFormat": ""
         }
     }
 }


### PR DESCRIPTION
adding support for node 16 runners as per https://devblogs.microsoft.com/devops/node-runner-update-guidance-for-azure-pipelines-task-authors/