### PR TITLE
Support promoting Maven packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "promote-artifact-version-azure-pipeline-task",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "ISC",
       "dependencies": {
         "azure-pipelines-task-lib": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promote-artifact-version-azure-pipeline-task",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Task for promoting artifact versions in package feeds on azure devops",
   "main": "index.js",
   "scripts": {

--- a/src/promote-artifact-version-task/index.ts
+++ b/src/promote-artifact-version-task/index.ts
@@ -128,6 +128,11 @@ async function run() {
             case 'pypi': 
                 updateUrl = `/${urlPrefixSegment}/_apis/Packaging/Feeds/${packageFeed.id}/${feedType}/packages/${pkg.name}/versions/${pkgVersion.version}?api-version=5.0-preview.1`;
                 break;
+            case 'maven':
+                let groupId = pkg.name.split(':')[0]
+                let artifactId = pkg.name.split(':')[1]
+                updateUrl = `/${urlPrefixSegment}/_apis/Packaging/Feeds/${packageFeed.id}/maven/groups/${groupId}/artifacts/${artifactId}/versions/${pkgVersion.version}?api-version=5.0-preview.1`
+                break;
             default: 
                 updateUrl = `/${urlPrefixSegment}/_apis/Packaging/Feeds/${packageFeed.id}/${feedType}/packages/${pkg.name}/versions/${pkgVersion.version}?api-version=5.0-preview.1`;
         }


### PR DESCRIPTION
Fixes issue #3 with trying to promote Maven packages in a feed.

Maven packages are identified by a group and artifactId which are encoded in the package name as "${group}:${artifactId}".  API endpoints for working with Maven packages use "${group}/${artifactId}" in the path instead of just ${name}.

https://learn.microsoft.com/en-us/rest/api/azure/devops/artifactspackagetypes/maven/update-package-version?view=azure-devops-rest-7.1

Let me know if you would still like to see a minimal Maven project that you can test this out yourself.  Thanks for the great tool!